### PR TITLE
Synaptic situation

### DIFF
--- a/dbbs_models/golgi_cell_models.py
+++ b/dbbs_models/golgi_cell_models.py
@@ -20,7 +20,7 @@ class GolgiCell(DbbsNeuronModel):
         "AMPA_MF": {
             "point_process": ('AMPA', 'granule'),
         },
-        
+
         "NMDA": {
             "point_process": ('NMDA', 'stellate'),
             "attributes": {
@@ -51,7 +51,7 @@ class GolgiCell(DbbsNeuronModel):
             "mechanisms": [], "attributes": {}
         },
         "basal_dendrites": {
-            "synapses": ['AMPA_MF', 'AMPA_PF', 'NMDA'],
+            "synapses": ['AMPA_AA', 'AMPA_MF', 'NMDA'],
             "mechanisms": ['Leak','Nav1_6','Kca1_1','Kca2_2','Ca',('cdp5', 'CAM_GoC')],
             "attributes": {
                 "Ra": 122, "cm": 2.5, "ena": 60, "ek": -80, "eca": 137,
@@ -65,7 +65,7 @@ class GolgiCell(DbbsNeuronModel):
             }
         },
         "apical_dendrites": {
-            "synapses": ['AMPA_MF', 'AMPA_PF'],
+            "synapses": ['AMPA_PF'],
             "mechanisms": ['Leak', 'Nav1_6', 'Kca1_1', 'Kca2_2', 'Cav2_3', 'Cav3_1', ('cdp5', 'CAM_GoC')],
             "attributes":  {
                 "Ra": 122, "cm": 2.5, "ena": 60, "ek": -80, "eca": 137,

--- a/dbbs_models/golgi_cell_models.py
+++ b/dbbs_models/golgi_cell_models.py
@@ -11,11 +11,21 @@ class GolgiCell(DbbsNeuronModel):
                 "tau_facil": 54, "tau_rec": 35.1, "tau_1": 30, "gmax": 1200, "U": 0.4
             }
         },
+        "AMPA_AA": {
+            "point_process": 'AMPA',
+            "attributes": {
+                "tau_facil": 54, "tau_rec": 35.1, "tau_1": 30, "gmax": 1200, "U": 0.4
+            }
+        },
         "AMPA_MF": {
             "point_process": ('AMPA', 'granule'),
         },
+        
         "NMDA": {
-            "point_process": ('NMDA', 'granule')
+            "point_process": ('NMDA', 'stellate'),
+            "attributes": {
+                "tau_facil": 5, "tau_rec": 8, "tau_1": 1, "gmax": 10000, "U": 0.43
+            }
         }
     }
 


### PR DESCRIPTION
The AMPA_PF and AMPA_AA are the same, with the same parameters and same MOD file used in PF PC and PF -SC

AMPA_PF is alone.
AMPA_AA is used with NMDA stellate
AMPA_MF is used with NMDA stellate

### Sections for PF
```
if sec_index >= 4 and sec_index <= 15 or sec_index >= 18 and sec_index <= 32 or sec_index >= 42 and sec_index <= 83 or sec_index >= 85 and sec_index <= 104:
```

### Sections for MF and AA.
```
if sec_index >= 108 and sec_index <= 112 or sec_index >= 114 and sec_index <= 121 or sec_index >= 128 and sec_index <= 129 or sec_index >= 131 and sec_index <= 132 or sec_index >= 135 and sec_index <= 140 or sec_index >= 144 and sec_index <= 145 or sec_index >= 147 and sec_index <= 150:
```

https://github.com/dbbs-lab/models/issues/2

> To summarize.
>
> Golgi AMPA_PF/AA - PC, SC, BC are the same mod with different "external" values".
> Golgi AMPA_MF - The MOD is the one for the granule cell and it is valid only for MF-GrC and MF-GoC
>
> Golgi NMDA_AA and NMDA_MF - Stellate NMDA
>
> Granule cell NMDA - Only used for granule cells"